### PR TITLE
Missing semicolon fix for communityofflineserver.c

### DIFF
--- a/DayZ-Sa-Tomato/addons/DayZ-SA-Tomato/scripts/5_Mission/core/CommunityOfflineServer.c
+++ b/DayZ-Sa-Tomato/addons/DayZ-SA-Tomato/scripts/5_Mission/core/CommunityOfflineServer.c
@@ -159,7 +159,7 @@ class CommunityOfflineServer : MissionServer
 			vector pos;
 				
 			pos = currentPlayer.GetPosition();
-			CLogDebug("CommunityOfflineServer - SendPosTOAdmins1/2() - Name :" + PlayerName + "pos : " + pos)
+			CLogDebug("CommunityOfflineServer - SendPosTOAdmins1/2() - Name :" + PlayerName + "pos : " + pos);
 			//SendPosToAdmins(PlayerName, pos);
 			m_currentPlayer1++;
 			
@@ -182,7 +182,7 @@ class CommunityOfflineServer : MissionServer
 				PlayerSteam64ID1 = AdminIdent1.GetPlainId();
 				if (IsAdmin(AdminPlayerName1, PlayerSteam64ID1 ))
 				{
-					CLogDebug("CommunityOfflineServer - SendPosTOAdmins2/2() - Name :" + PlayerName + "pos : " + pos)
+					CLogDebug("CommunityOfflineServer - SendPosTOAdmins2/2() - Name :" + PlayerName + "pos : " + pos);
 					ScriptRPC PPos = new ScriptRPC();
 					PPos.Write(PlayerName);
 					PPos.Write(pos);


### PR DESCRIPTION
Fix for:
SCRIPT    (W): @"com/DayZ-SA-Tomato/scripts/5_Mission/core\communityofflineserver.c,162": Missing ';' at the end of line
SCRIPT    (W): @"com/DayZ-SA-Tomato/scripts/5_Mission/core\communityofflineserver.c,185": Missing ';' at the end of line